### PR TITLE
Add Theileria orientalis genomes to prod name list

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -80,6 +80,8 @@ sub update_conf {
         trypanosoma_brucei_gca003072535v3
         tetrahymena_thermophila
         thalassiosira_pseudonana
+        theileria_orientalis_gca003072535
+        theileria_orientalis_gca003072545
         toxoplasma_gondii
         trypanosoma_brucei
       ),


### PR DESCRIPTION
This PR would add genomes `theileria_orientalis_gca003072535` and `theileria_orientalis_gca003072545` to the production name list in the `SiteDefs.pm` file, making them visible on the Ensembl Protists 114 website.

Example species list view before this change:
![e114_theileria_orientalis_list_before](https://github.com/user-attachments/assets/1064bf06-e83f-4119-890b-4c81a180ad84)

Example species list view after this change:
![e114_theileria_orientalis_list_after](https://github.com/user-attachments/assets/bc6fd4a9-79d3-4c2f-a14a-0f68e07d7a87)